### PR TITLE
Make sure service run files are executable

### DIFF
--- a/moj-base/Dockerfile
+++ b/moj-base/Dockerfile
@@ -24,6 +24,8 @@ ADD certs /etc/certs
 # install service files for runit
 ADD logstash.service /etc/service/logstash/run
 ADD statsd.service /etc/service/statsd/run
+RUN chmod +x /etc/service/logstash/run
+RUN chmod +x /etc/service/statsd/run
 
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Some versions of docker don’t preserve permissions, so just make sure they are right
