### PR TITLE
Add tagging based on the git tag to the docker image

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,8 +1,10 @@
-
 CWD=`pwd`
-
+#This gets the tag that's currently checked out
+TAG=`git name-rev --tags --name-only $(git rev-parse HEAD)|cut -f1 -d '^'`
 for img in moj-base moj-nginx moj-ruby moj-peoplefinder light; do
-	cd $CWD/$img
-	docker build -t $img .
+    cd $CWD/$img
+    docker build -t $img .
+    if [ "$TAG" != "undefined" ]; then
+        docker tag $img:latest $img:$TAG
+    fi
 done
-


### PR DESCRIPTION
@ashb what do you think of this? Any better ideas?

My goal is to update the ruby version in moj-ruby but leave a mechanism for some projects to use an older version of the container.