### PR TITLE
[moj-base] Remove node symlinking in Dockerfile

### DIFF
--- a/moj-base/Dockerfile
+++ b/moj-base/Dockerfile
@@ -21,9 +21,6 @@ RUN apt-get install --only-upgrade bash
 RUN apt-get install -y  openjdk-7-jre-headless
 RUN apt-get install -y --force-yes statsd netcat-traditional logstash
 
-# Fix broken path to so that 'env node' works again
-RUN ln -s /usr/bin/nodejs /usr/bin/node
-
 # Ensure logstash user is member of adm group so it can read logs in /var/log
 RUN usermod -a -G adm logstash
 


### PR DESCRIPTION
Dockerfile symlinking to node is breaks build since it exists on
default install now. This is no longer needed so just don't do
the workaround. (Closes #26)