### PR TITLE
Allow passing a registry on the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ This repo contains Dockerfiles for basing project specific docker images from.
 `./make.sh` in the top level directory will build all the images contained in
 this repo
 
+Passing a parameter will also allow pushing the images to a local registry. 
+For example, to build and push images to the local repository
+docker.local:5000, 
+
+`./make.sh docker.local:5000`
 
 # Using images on other hosts
 

--- a/make.sh
+++ b/make.sh
@@ -1,8 +1,34 @@
-
+#!/bin/sh
+# set -x
 CWD=`pwd`
+
+if [ "$1" ]; then
+    REGISTRY="$1"
+    echo Setting local registry ${REGISTRY} for pushing...
+    # See if we can find the registry
+    echo Looking for registry ${REGISTRY}...
+    response_v1=$(curl --insecure --write-out %{http_code} --silent --output /dev/null https://${REGISTRY}/v1/)
+    response_v2=$(curl --insecure --write-out %{http_code} --silent --output /dev/null https://${REGISTRY}/v2/)
+    if [ "${response_v1}" == "200" ] || [ "${response_v2}" == "200" ]; then
+        echo Contacted registry ${REGISTRY}, using this for pushing images
+    else
+        echo Could not contact registry ${REGISTRY}, exiting
+        exit 1
+    fi
+fi
 
 for img in moj-base moj-nginx moj-ruby moj-peoplefinder light; do
 	cd $CWD/$img
-	docker build -t $img .
+    echo Building local image ${img}
+	docker build -t ${img} .
+    if [ "${response_v1}" == "200" ] || [ "${response_v2}" == "200" ]; then
+        remote_name=${REGISTRY}/$img
+	    docker tag ${img} ${remote_name}
+        echo Uploading ${remote_name} to ${REGISTRY}
+        docker push ${remote_name}
+    else
+        echo No remote registry specified...skipping push
+    fi
 done
 
+exit 0

--- a/moj-base/Dockerfile
+++ b/moj-base/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y  openjdk-7-jre-headless
 RUN apt-get install -y --force-yes statsd netcat-traditional logstash
 
 # Fix broken path to so that 'env node' works again
-RUN ln -s /usr/bin/nodejs /usr/bin/node
+# RUN ln -s /usr/bin/nodejs /usr/bin/node
 
 # Ensure logstash user is member of adm group so it can read logs in /var/log
 RUN usermod -a -G adm logstash


### PR DESCRIPTION
By passing a local docker registry on the command line, the
images will not only be built, but will also be pushed to the
specified local docker registry. e.g

./make.sh docker.local:5000