### PR TITLE
Fix node symlink problem on container build

### DIFF
--- a/moj-base/Dockerfile
+++ b/moj-base/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ###
 ### Added ruby 2.2
 ###
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 914D5813 
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 914D5813
 RUN echo "deb http://ppa.launchpad.net/gds/govuk/ubuntu precise main" > /etc/apt/sources.list.d/gds-govuk-precise.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D88E42B4
 RUN echo 'deb http://packages.elasticsearch.org/logstash/1.4/debian stable main' > /etc/apt/sources.list.d/logstash.list
@@ -20,9 +20,6 @@ RUN apt-get install --only-upgrade bash
 # The default netcat hangs when UDP transport is specified
 RUN apt-get install -y  openjdk-7-jre-headless
 RUN apt-get install -y --force-yes statsd netcat-traditional logstash
-
-# Fix broken path to so that 'env node' works again
-RUN ln -s /usr/bin/nodejs /usr/bin/node
 
 # Ensure logstash user is member of adm group so it can read logs in /var/log
 RUN usermod -a -G adm logstash


### PR DESCRIPTION
- Removed trailing whitespace
- Fixed an error that was occurring in the build

The symlink is no longer relevant, and generates an error on the build:

```
docker build -t moj-base .
Sending build context to Docker daemon 1.679 MB
Sending build context to Docker daemon
Step 0 : FROM phusion/baseimage:0.9.16
 ---> 5a14c1498ff4
...
Step 11 : RUN ln -s /usr/bin/nodejs /usr/bin/node
 ---> Running in 99c4ac52b78c
ln: failed to create symbolic link '/usr/bin/node': File exists
INFO[0001] The command [/bin/sh -c ln -s /usr/bin/nodejs /usr/bin/node] returned a non-zero code: 1
```

```
Oskars-MacBook-Pro:docker-templates oskar$ docker run -t -i 847bc8ffdfca /bin/bash
root@951f257d2be2:/# ls -la  /usr/bin/node
lrwxrwxrwx 1 root root 22 Jun  9 14:44 /usr/bin/node -> /etc/alternatives/node
root@951f257d2be2:/# env node
> root@951f257d2be2:/# exit
Oskars-MacBook-Pro:docker-templates oskar$ docker run -t -i 847bc8ffdfca /bin/bash
root@88128b50a2d5:/# ls -la  /usr/bin/node
lrwxrwxrwx 1 root root 22 Jun  9 14:44 /usr/bin/node -> /etc/alternatives/node
root@88128b50a2d5:/# ls -al /etc/alternatives/node
lrwxrwxrwx 1 root root 15 Jun  9 14:44 /etc/alternatives/node -> /usr/bin/nodejs
root@88128b50a2d5:/# ls -al /usr/bin/nodejs
-rwxr-xr-x 1 root root 8860272 Apr  7 14:29 /usr/bin/nodejs
root@88128b50a2d5:/# env node
>
```