### PR TITLE
Fix the vagrantfile box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "precise64"
+  config.vm.box = "ubuntu/precise64"
 
 # Install latest docker
   config.vm.provision "docker"


### PR DESCRIPTION
This change will rename the vagrant file box from precise64 to
ubuntu/precise64.

(Fixes #2)